### PR TITLE
Topology optimization example

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ only_build_toc_files: true
 # See https://jupyterbook.org/content/execute.html
 execute:
   execute_notebooks: cache
-  timeout: 360
+  timeout: 600
 
 # Information about where the book exists on the web
 repository:

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ only_build_toc_files: true
 # See https://jupyterbook.org/content/execute.html
 execute:
   execute_notebooks: cache
-  timeout: 100
+  timeout: 250
 
 # Information about where the book exists on the web
 repository:

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ only_build_toc_files: true
 # See https://jupyterbook.org/content/execute.html
 execute:
   execute_notebooks: cache
-  timeout: 250
+  timeout: 360
 
 # Information about where the book exists on the web
 repository:

--- a/_toc.yml
+++ b/_toc.yml
@@ -2,14 +2,19 @@ format: jb-book
 root: README.md
 
 parts:
-  - caption: Examples
+  - caption: Introduction
     chapters:
     - file: "demos/poisson_mother.py"
-    - file: "demos/time_distributed_control.py"
-    - file: "demos/time_distributed_control_checkpointing.py"
+    - file: "demos/boundary_control.py"
+    - file: "demos/topology_optimization.py"
     - file: "demos/demo_nonmatching_grids.py"
     - file: "demos/emi_membrane_current_control.py"
-    - file: "demos/boundary_control.py"
+
+  - caption: Time-dependent PDE control
+    chapters:
+    - file: "demos/time_distributed_control.py"
+    - file: "demos/time_distributed_control_checkpointing.py"
+
   - caption: Python API
     chapters:
     - file: "docs/api"

--- a/demos/emi_membrane_current_control.py
+++ b/demos/emi_membrane_current_control.py
@@ -1,4 +1,4 @@
-# # Optimal control of the EMI equations
+# # Optimal control with submeshes and interface coupling
 # *Author: Jørgen S. Dokken ([dokken@simula.no](mailto:dokken@simula.no))*.
 
 # This demo is a second a stepping stone up from the

--- a/demos/topology_optimization.py
+++ b/demos/topology_optimization.py
@@ -1,0 +1,372 @@
+# # Topology Optimization of a Linear-Elastic Cantilever (SIMP)
+# *Section author: Jørgen S. Dokken ([dokken@simula.no](mailto:dokken@simula.no))*.
+#
+# This demo reproduces the 3D cantilever-beam topology optimization problem from
+# [Pasteur Labs' Mosaic benchmark suite][mosaic-results], using `dolfinx_adjoint` in
+# place of the original FEniCS/dolfin-adjoint solver. The mesh, material model,
+# boundary conditions and objective follow Mosaic's own reference implementation
+# exactly:
+#
+# - [`fenics-structural/tesseract_api.py`][mosaic-tesseract] — the FEniCS/dolfin-adjoint
+#   physics kernel this demo's weak form and compliance functional mirror.
+# - [`benchmarks/problems/structural_mesh/{physics,optimization,config}.py`][mosaic-benchmark] —
+#   the cantilever boundary-condition builder and the canonical run configuration
+#   (mesh resolution, material parameters, volume-fraction target) reproduced below.
+#
+# The optimizer differs from Mosaic's own Adam-based recipe: this demo uses
+# `scipy.optimize.minimize(method="trust-constr")`, driven by a
+# `pyadjoint.ReducedFunctionalNumPy`, which — unlike Mosaic's Adam + manual clipping —
+# enforces the SIMP density bounds natively via `bounds=` while also using exact
+# Hessian-vector products from the adjoint/tangent-linear system (`hessp=`), something
+# Mosaic's first-order Adam recipe does not use at all.
+#
+# The per-iteration density animation uses the pyvista GIF-writing pattern from
+# [`dolfinx-tutorial/chapter2/amr.py`][tutorial-amr].
+#
+# [mosaic-results]: https://docs.pasteurlabs.ai/projects/mosaic/stable/docs/results_structural_mesh.html
+# [mosaic-tesseract]: https://github.com/pasteurlabs/mosaic/blob/main/mosaic/tesseracts/structural-mesh/fenics-structural/tesseract_api.py
+# [mosaic-benchmark]: https://github.com/pasteurlabs/mosaic/tree/main/mosaic/benchmarks/problems/structural_mesh
+# [tutorial-amr]: https://github.com/jorgensd/dolfinx-tutorial/blob/c752d010ddbabf98b3e71e7a562f07ad7a738c26/chapter2/amr.py#L241
+
+# ## Problem definition
+#
+# We minimize the structural compliance $C = \mathbf F^\top \mathbf u$ of a linear
+# elastic body $\Omega$ subject to
+#
+# $$
+# -\operatorname{div}(\sigma(\mathbf u)) = 0 \quad \text{in } \Omega, \qquad
+# \mathbf u = 0 \quad \text{on } \Gamma_D, \qquad
+# \sigma(\mathbf u)\cdot n = \mathbf t \quad \text{on } \Gamma_N,
+# $$
+#
+# with a SIMP-interpolated, density-dependent stiffness
+#
+# $$
+# E(\rho) = E_\min + (E_\max - E_\min)\,\rho^p, \qquad E_\min = x_\min E_\max,
+# $$
+#
+# and a soft volume-fraction penalty added to the objective,
+#
+# $$
+# \min_{x_\min \le \rho \le 1} \; J(\rho) = C(\rho) + w\,(\bar\rho - v_\mathrm{frac})^2,
+# \qquad \bar\rho = \frac{1}{|\Omega|}\int_\Omega \rho \, \mathrm{d}x.
+# $$
+#
+# The domain is a $[0,2]\times[0,1]\times[0,1]$ cantilever beam meshed with HEX8
+# elements ($16\times2\times8$ elements), clamped at $x=0$. A prescribed total force
+# $F_\mathrm{total}$ is applied at $x=2$, either as a uniform downward traction over
+# the whole face, or as a concentrated upward traction on a single corner patch — both
+# cases are run below.
+
+# ## Implementation
+#
+# We start by importing the necessary modules.
+
+# +
+import time
+
+from mpi4py import MPI
+
+import dolfinx
+import numpy as np
+import pandas
+import pyadjoint
+import pyvista
+import scipy.optimize
+import ufl
+
+import dolfinx_adjoint
+
+# -
+
+# We configure Pyvista for rendering.
+
+# + tags=["hide-input"]
+pyvista.set_jupyter_backend("html")
+# -
+
+# ## Material and problem parameters
+#
+# These match Mosaic's canonical `optimization/topopt` run exactly (see
+# `mosaic/benchmarks/problems/structural_mesh/config.py`).
+
+# +
+Lx, Ly, Lz = 2.0, 1.0, 1.0
+F_total = 1.0
+
+E_max = 70_000.0  # Young's modulus of the fully solid material [MPa]
+nu = 0.3  # Poisson's ratio
+x_min = 1.0e-3  # void stiffness ratio (E_min = x_min * E_max) and density lower bound
+penal = 3.0  # SIMP penalization exponent
+
+v_frac = 0.5  # target volume fraction
+penalty_weight = 50.0  # volume-fraction penalty weight
+# -
+
+
+# ## Mesh and boundary conditions
+#
+# `build_mesh_and_bcs` mirrors Mosaic's own `_cantilever_bcs`
+# (`mosaic/benchmarks/problems/structural_mesh/physics.py`): all nodes at $x=0$ are
+# clamped, and the load on the $x=L_x$ face is either a uniform downward traction, or
+# a concentrated upward traction on the single corner patch $y\in[0,\Delta y]$,
+# $z\in[0,\Delta z]$. `dolfinx.mesh.locate_entities_boundary` selects a facet only when
+# *all* of its vertices satisfy the marker, matching the "all vertices in group"
+# semantics Mosaic's own node-mask approach uses.
+
+
+def build_mesh_and_bcs(nx: int, ny: int, nz: int, corner_load: bool):
+    """Build the cantilever mesh, Dirichlet facets, Neumann measure and traction."""
+    msh = dolfinx.mesh.create_box(
+        MPI.COMM_WORLD,
+        [np.array([0.0, 0.0, 0.0]), np.array([Lx, Ly, Lz])],
+        (nx, ny, nz),
+        dolfinx.mesh.CellType.hexahedron,
+    )
+    fdim = msh.topology.dim - 1
+    msh.topology.create_connectivity(fdim, msh.topology.dim)
+    tol = 1.0e-6 * max(Lx, Ly, Lz)
+
+    left_facets = dolfinx.mesh.locate_entities_boundary(msh, fdim, lambda x: x[0] < tol)
+
+    if corner_load:
+        dy, dz = Ly / ny, Lz / nz
+        right_facets = dolfinx.mesh.locate_entities_boundary(
+            msh, fdim, lambda x: (x[0] > Lx - tol) & (x[1] < dy + tol) & (x[2] < dz + tol)
+        )
+        traction = (0.0, 0.0, F_total / (dy * dz))  # concentrated, upward
+    else:
+        right_facets = dolfinx.mesh.locate_entities_boundary(msh, fdim, lambda x: x[0] > Lx - tol)
+        traction = (0.0, 0.0, -F_total / (Ly * Lz))  # uniform, downward
+
+    right_facets = np.sort(right_facets)
+    facet_tags = dolfinx.mesh.meshtags(msh, fdim, right_facets, np.full(len(right_facets), 1, dtype=np.int32))
+    ds = ufl.Measure("ds", domain=msh, subdomain_data=facet_tags)
+    return msh, left_facets, ds, np.array(traction, dtype=dolfinx.default_scalar_type)
+
+
+# ## Per-iteration density visualization
+#
+# We record the density field once per outer optimizer iteration into a GIF, using the
+# pyvista pattern from `dolfinx-tutorial/chapter2/amr.py`. Since a SIMP density field
+# lives in a `("DG", 0)` space, its dof array maps 1-to-1 onto the local cell
+# numbering, so it can be attached directly as `cell_data` on a grid built from the
+# mesh itself (not from the function space).
+
+
+def make_gif_writer(msh: dolfinx.mesh.Mesh, rho: dolfinx_adjoint.Function, gif_path: str):
+    """Return (plotter, callback) that appends one frame per optimizer iteration."""
+    plotter = pyvista.Plotter(off_screen=True)
+    plotter.open_gif(gif_path, fps=10)
+
+    def write_frame():
+        grid = pyvista.UnstructuredGrid(*dolfinx.plot.vtk_mesh(msh))
+        grid.cell_data["rho"] = rho.x.array
+        actor = plotter.add_mesh(grid, scalars="rho", clim=(0.0, 1.0), cmap="viridis", show_edges=False)
+        plotter.view_isometric()
+        plotter.write_frame()
+        plotter.remove_actor(actor)
+
+    def gif_callback(intermediate_result):
+        rho.x.array[:] = intermediate_result.x
+        rho.x.scatter_forward()
+        write_frame()
+
+    write_frame()  # record the initial, uniform density as frame 0
+    return plotter, gif_callback
+
+
+# ## Forward model, gradient verification and optimization
+#
+# `run_topopt` builds the forward model once (SIMP weak form, linear solve, compliance
+# + volume-penalty objective), verifies the resulting adjoint gradient and Hessian with
+# 0th/1st/2nd-order Taylor tests, times a single tape recompute and a single adjoint
+# solve, then optimizes the density with a bound- and curvature-aware scipy solver.
+#
+# ```{note}
+# A `pyadjoint.ReducedFunctional` *replays* the tape it was built from — it does not
+# re-execute Python code. The forward model below therefore calls `problem.solve()`
+# with annotation on exactly once; every subsequent evaluation goes through
+# `Jhat(...)`/`Jhat.derivative()`/`Jhat.hessian(...)`. `problem` is also kept alive as a
+# local variable for as long as `Jhat` is used, since letting it go out of scope would
+# silently fall back to a much slower solver-rebuild path.
+# ```
+
+
+def run_topopt(corner_load: bool, nx: int = 16, ny: int = 2, nz: int = 8) -> dict:
+    case_name = "corner_load" if corner_load else "full_face_load"
+    print(f"\n=== Running topology optimization: {case_name} ===")
+
+    pyadjoint.get_working_tape().clear_tape()
+
+    msh, left_facets, ds, traction = build_mesh_and_bcs(nx, ny, nz, corner_load)
+    fdim = msh.topology.dim - 1
+
+    # ### Function spaces and control
+    V = dolfinx.fem.functionspace(msh, ("Lagrange", 1, (3,)))  # displacement
+    Q = dolfinx.fem.functionspace(msh, ("DG", 0))  # density
+
+    rho = dolfinx_adjoint.Function(Q, name="Density")
+    rho.x.array[:] = v_frac
+    rho.x.scatter_forward()
+
+    uh = dolfinx_adjoint.Function(V, name="Displacement")
+
+    # ### SIMP material law and weak form
+    E_min = x_min * E_max
+    E = E_min + (E_max - E_min) * rho**penal
+    lam = E * nu / ((1 + nu) * (1 - 2 * nu))
+    mu = E / (2 * (1 + nu))
+
+    def eps(w):
+        return ufl.sym(ufl.grad(w))
+
+    def sigma(w):
+        return lam * ufl.tr(eps(w)) * ufl.Identity(3) + 2 * mu * eps(w)
+
+    u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
+    a = ufl.inner(sigma(u), eps(v)) * ufl.dx
+    t = dolfinx.fem.Constant(msh, traction)
+    L = ufl.inner(t, v) * ds(1)
+
+    # ### Dirichlet BC and forward solve (once)
+    bdofs = dolfinx.fem.locate_dofs_topological(V, fdim, left_facets)
+    bc = dolfinx.fem.dirichletbc(np.zeros(3, dtype=dolfinx.default_scalar_type), bdofs, V)
+
+    petsc_options = {
+        "ksp_type": "preonly",
+        "pc_type": "lu",
+        "pc_factor_mat_solver_type": "mumps",
+        "ksp_error_if_not_converged": True,
+    }
+    problem = dolfinx_adjoint.LinearProblem(
+        a,
+        L,
+        u=uh,
+        bcs=[bc],
+        petsc_options=petsc_options,
+        adjoint_petsc_options=petsc_options,
+        tlm_petsc_options=petsc_options,
+    )
+
+    t_forward_start = time.perf_counter()
+    problem.solve()
+    forward_time = time.perf_counter() - t_forward_start
+    print(f"[{case_name}] initial forward solve: {forward_time:.4e} s")
+
+    # ### Objective: compliance + volume-fraction penalty
+    compliance = dolfinx_adjoint.assemble_scalar(ufl.action(L, uh))
+    vol_frac = dolfinx_adjoint.assemble_scalar(rho * ufl.dx) / (Lx * Ly * Lz)
+    J = compliance + penalty_weight * (vol_frac - v_frac) ** 2
+
+    control = pyadjoint.Control(rho)
+    Jhat = pyadjoint.ReducedFunctional(J, control)
+
+    # ### Gradient and Hessian verification: 0th, 1st and 2nd-order Taylor tests
+    #
+    # Matches the convention used throughout `dxa/tests/` (e.g.
+    # `tests/test_linear_solver.py`, `demos/demo_nonmatching_grids.py`) rather than the
+    # (unused-in-this-repo) upstream `pyadjoint.taylor_to_dict` helper.
+    with pyadjoint.stop_annotating():
+        h = dolfinx_adjoint.Function(Q)
+        rng = np.random.default_rng(seed=42)
+        h.x.array[:] = rng.standard_normal(len(h.x.array))
+        h.x.scatter_forward()
+
+        rate0 = pyadjoint.taylor_test(Jhat, rho, h, dJdm=0)
+        print(f"[{case_name}] 0th-order Taylor rate (expect ~1): {rate0:.4f}")
+        rate1 = pyadjoint.taylor_test(Jhat, rho, h)
+        print(f"[{case_name}] 1st-order Taylor rate (expect ~2): {rate1:.4f}")
+
+        Jhat(rho)
+        dJdm = Jhat.derivative()._ad_dot(h)
+        dHddu = Jhat.hessian(h)._ad_dot(h)
+        rate2 = pyadjoint.taylor_test(Jhat, rho, h, dJdm=dJdm, Hm=dHddu)
+        print(f"[{case_name}] 2nd-order Taylor rate (expect ~3): {rate2:.4f}")
+
+    # ### Cost of one recompute vs. one adjoint solve
+    #
+    # Mirrors the forward-vs-VJP cost split Mosaic itself tracks separately
+    # (`cost/spatial_cost` vs `cost/vjp_cost`).
+    t_recompute_start = time.perf_counter()
+    Jhat(rho)
+    recompute_time = time.perf_counter() - t_recompute_start
+    print(f"[{case_name}] one tape recompute (Jhat(rho)): {recompute_time:.4e} s")
+
+    t_derivative_start = time.perf_counter()
+    Jhat.derivative()
+    derivative_time = time.perf_counter() - t_derivative_start
+    print(f"[{case_name}] one adjoint solve (Jhat.derivative()): {derivative_time:.4e} s")
+
+    # ### Bound- and curvature-aware optimization
+    #
+    # `scipy.optimize.minimize(method="trust-constr")` is the scipy method that accepts
+    # *both* `bounds=` and a Hessian-vector product (`hessp=`); `pyadjoint.minimize`'s
+    # convenience wrapper only wires `hessp` automatically for `method="Newton-CG"`
+    # (which has no bounds support), so we drive `scipy.optimize.minimize` directly
+    # from a `pyadjoint.reduced_functional_numpy.ReducedFunctionalNumPy` — the same public class
+    # `pyadjoint.minimize` itself wraps every call in.
+    plotter, gif_callback = make_gif_writer(msh, rho, f"topopt_{case_name}.gif")
+
+    rf_np = pyadjoint.reduced_functional_numpy.ReducedFunctionalNumPy(Jhat)
+    m0 = rf_np.get_controls()
+
+    t_optim_start = time.perf_counter()
+    res = scipy.optimize.minimize(
+        fun=rf_np.__call__,
+        x0=m0,
+        jac=lambda m: rf_np.derivative(),
+        hessp=lambda m, p: rf_np.hessian(p),
+        method="trust-constr",
+        bounds=scipy.optimize.Bounds(x_min, 1.0),
+        callback=gif_callback,
+        options={"maxiter": 200, "verbose": 2},
+    )
+    optim_time = time.perf_counter() - t_optim_start
+    print(f"[{case_name}] trust-constr optimization: {optim_time:.4e} s over {res.nit} iterations")
+
+    rho_opt = rf_np.set_controls(res.x)[0]
+    rho.x.array[:] = rho_opt.x.array
+    rho.x.scatter_forward()
+    problem.solve(annotate=False)
+    plotter.close()
+
+    # Final compliance/volume fraction as plain floats.
+    final_compliance = dolfinx_adjoint.assemble_scalar(ufl.action(L, uh), annotate=False)
+    final_vol_frac = dolfinx_adjoint.assemble_scalar(rho * ufl.dx, annotate=False) / (Lx * Ly * Lz)
+
+    # Static screenshot of the converged density field.
+    grid = pyvista.UnstructuredGrid(*dolfinx.plot.vtk_mesh(msh))
+    grid.cell_data["rho"] = rho.x.array
+    final_plotter = pyvista.Plotter(off_screen=pyvista.OFF_SCREEN)
+    final_plotter.add_mesh(grid, scalars="rho", clim=(0.0, 1.0), cmap="viridis", show_edges=False)
+    final_plotter.view_isometric()
+    if pyvista.OFF_SCREEN:
+        final_plotter.screenshot(f"topopt_{case_name}_final.png")
+    else:
+        final_plotter.show()
+
+    return {
+        "case": case_name,
+        "compliance": float(final_compliance),
+        "vol_frac": float(final_vol_frac),
+        "n_iterations": int(res.nit),
+        "forward_time": forward_time,
+        "recompute_time": recompute_time,
+        "derivative_time": derivative_time,
+        "optim_time": optim_time,
+    }
+
+
+# ## Running both load cases
+#
+# Mosaic's canonical `optimization/topopt` run uses `corner_load=True`; we additionally
+# run the uniform full-face load for comparison.
+
+results = [run_topopt(corner_load=True), run_topopt(corner_load=False)]
+
+# ## Summary
+
+summary = pandas.DataFrame(results).set_index("case")
+print("\n=== Summary ===")
+print(summary)

--- a/demos/topology_optimization.py
+++ b/demos/topology_optimization.py
@@ -68,6 +68,7 @@ import time
 from mpi4py import MPI
 
 import dolfinx
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas
 import pyadjoint
@@ -145,19 +146,30 @@ def build_mesh_and_bcs(nx: int, ny: int, nz: int, corner_load: bool):
     return msh, left_facets, ds, np.array(traction, dtype=dolfinx.default_scalar_type)
 
 
-# ## Per-iteration density visualization
+# ## Per-iteration density visualization and compliance history
 #
 # We record the density field once per outer optimizer iteration into a GIF, using the
 # pyvista pattern from `dolfinx-tutorial/chapter2/amr.py`. Since a SIMP density field
 # lives in a `("DG", 0)` space, its dof array maps 1-to-1 onto the local cell
 # numbering, so it can be attached directly as `cell_data` on a grid built from the
-# mesh itself (not from the function space).
+# mesh itself (not from the function space). The same callback also records the pure
+# compliance (not the volume-penalized objective) at each iteration, for the
+# compliance-vs-iteration convergence plot Mosaic's own results page shows.
+#
+# `scipy.optimize.minimize` reports only the penalized objective
+# (`intermediate_result.fun`), so the pure compliance is recovered arithmetically:
+# since every cell of this structured box mesh has equal volume, the volume fraction is
+# exactly `rho.x.array.mean()`, so `compliance = fun - penalty_weight*(vol_frac - v_frac)**2`
+# recovers it with no extra PDE solve.
 
 
-def make_gif_writer(msh: dolfinx.mesh.Mesh, rho: dolfinx_adjoint.Function, gif_path: str):
-    """Return (plotter, callback) that appends one frame per optimizer iteration."""
+def make_iteration_tracker(
+    msh: dolfinx.mesh.Mesh, rho: dolfinx_adjoint.Function, gif_path: str, initial_compliance: float
+):
+    """Return (plotter, callback, compliance_history) tracking one optimizer run."""
     plotter = pyvista.Plotter(off_screen=True)
     plotter.open_gif(gif_path, fps=10)
+    compliance_history = [initial_compliance]
 
     def write_frame():
         grid = pyvista.UnstructuredGrid(*dolfinx.plot.vtk_mesh(msh))
@@ -167,13 +179,15 @@ def make_gif_writer(msh: dolfinx.mesh.Mesh, rho: dolfinx_adjoint.Function, gif_p
         plotter.write_frame()
         plotter.remove_actor(actor)
 
-    def gif_callback(intermediate_result):
+    def callback(intermediate_result):
         rho.x.array[:] = intermediate_result.x
         rho.x.scatter_forward()
         write_frame()
+        vol_frac = float(rho.x.array.mean())
+        compliance_history.append(intermediate_result.fun - penalty_weight * (vol_frac - v_frac) ** 2)
 
     write_frame()  # record the initial, uniform density as frame 0
-    return plotter, gif_callback
+    return plotter, callback, compliance_history
 
 
 # ## Forward model, gradient verification and optimization
@@ -306,7 +320,9 @@ def run_topopt(corner_load: bool, nx: int = 16, ny: int = 2, nz: int = 8) -> dic
     # (which has no bounds support), so we drive `scipy.optimize.minimize` directly
     # from a `pyadjoint.reduced_functional_numpy.ReducedFunctionalNumPy` — the same public class
     # `pyadjoint.minimize` itself wraps every call in.
-    plotter, gif_callback = make_gif_writer(msh, rho, f"topopt_{case_name}.gif")
+    plotter, callback, compliance_history = make_iteration_tracker(
+        msh, rho, f"topopt_{case_name}.gif", float(compliance)
+    )
 
     rf_np = pyadjoint.reduced_functional_numpy.ReducedFunctionalNumPy(Jhat)
     m0 = rf_np.get_controls()
@@ -319,7 +335,7 @@ def run_topopt(corner_load: bool, nx: int = 16, ny: int = 2, nz: int = 8) -> dic
         hessp=lambda m, p: rf_np.hessian(p),
         method="trust-constr",
         bounds=scipy.optimize.Bounds(x_min, 1.0),
-        callback=gif_callback,
+        callback=callback,
         options={"maxiter": 200, "verbose": 2},
     )
     optim_time = time.perf_counter() - t_optim_start
@@ -355,6 +371,7 @@ def run_topopt(corner_load: bool, nx: int = 16, ny: int = 2, nz: int = 8) -> dic
         "recompute_time": recompute_time,
         "derivative_time": derivative_time,
         "optim_time": optim_time,
+        "compliance_history": compliance_history,
     }
 
 
@@ -369,4 +386,19 @@ results = [run_topopt(corner_load=True), run_topopt(corner_load=False)]
 
 summary = pandas.DataFrame(results).set_index("case")
 print("\n=== Summary ===")
-print(summary)
+print(summary.drop(columns="compliance_history"))
+
+# ## Compliance convergence
+#
+# A compliance-vs-iteration plot, as shown on Mosaic's own results page.
+
+fig, ax = plt.subplots()
+for result in results:
+    ax.plot(result["compliance_history"], marker="o", markersize=3, label=result["case"])
+ax.set_xlabel("Iteration")
+ax.set_ylabel("Compliance $C = \\mathbf{F}^\\top \\mathbf{u}$")
+ax.set_title("SIMP topology optimization: compliance convergence")
+ax.legend()
+fig.savefig("topopt_compliance_convergence.png", dpi=150, bbox_inches="tight")
+if not pyvista.OFF_SCREEN:
+    plt.show()

--- a/demos/topology_optimization.py
+++ b/demos/topology_optimization.py
@@ -166,7 +166,8 @@ def make_iteration_tracker(
     def write_frame():
         grid = pyvista.UnstructuredGrid(*dolfinx.plot.vtk_mesh(msh))
         grid.cell_data["rho"] = rho.x.array
-        actor = plotter.add_mesh(grid, scalars="rho", clim=(0.0, 1.0), cmap="viridis", show_edges=False)
+        filtered_grid = grid.threshold(0.5, scalars="rho")
+        actor = plotter.add_mesh(filtered_grid, scalars="rho", clim=(0.0, 1.0), cmap="viridis", show_edges=False)
         plotter.view_isometric()
         plotter.write_frame()
         plotter.remove_actor(actor)
@@ -349,15 +350,16 @@ def optimize(
 
     # Final compliance/volume fraction as plain floats.
     uh = problem.u
-    L = problem.L
+    L = problem._rhs
     final_compliance = dolfinx_adjoint.assemble_scalar(ufl.action(L, uh), annotate=False)
     final_vol_frac = dolfinx_adjoint.assemble_scalar(rho * ufl.dx, annotate=False) / (Lx * Ly * Lz)
 
     # Static screenshot of the converged density field.
     grid = pyvista.UnstructuredGrid(*dolfinx.plot.vtk_mesh(msh))
     grid.cell_data["rho"] = rho.x.array
+    filtered_grid = grid.threshold(0.5, scalars="rho")
     final_plotter = pyvista.Plotter(off_screen=pyvista.OFF_SCREEN)
-    final_plotter.add_mesh(grid, scalars="rho", clim=(0.0, 1.0), cmap="viridis", show_edges=False)
+    final_plotter.add_mesh(filtered_grid, scalars="rho", clim=(0.0, 1.0), cmap="viridis", show_edges=False)
     final_plotter.view_isometric()
     if pyvista.OFF_SCREEN:
         final_plotter.screenshot(f"topopt_{case_name}_final.png")
@@ -378,10 +380,11 @@ def optimize(
 #
 # Mosaic's canonical `optimization/topopt` run uses `corner_load=True`; we additionally
 # run the uniform full-face load for comparison.
+# We use the settings from Figure 32 of {cite}`top-rehmann2026mosaic`, which uses a 32x4x16 mesh.
 
 results = []
 for corner_load in [True, False]:
-    Jhat, problem, compliance, rho, timings = run_topopt(corner_load)
+    Jhat, problem, compliance, rho, timings = run_topopt(corner_load, nx=32, ny=4, nz=16)
     result = optimize(rho, Jhat, problem, compliance, corner_load)
     result.update(timings)
     results.append(result)
@@ -406,3 +409,12 @@ ax.legend()
 fig.savefig("topopt_compliance_convergence.png", dpi=150, bbox_inches="tight")
 if not pyvista.OFF_SCREEN:
     plt.show()
+
+
+# ## References
+#
+# ```{bibliography}
+# :filter: cited
+# :labelprefix:
+# :keyprefix: top-
+# ```

--- a/demos/topology_optimization.py
+++ b/demos/topology_optimization.py
@@ -2,41 +2,34 @@
 # *Section author: Jørgen S. Dokken ([dokken@simula.no](mailto:dokken@simula.no))*.
 #
 # This demo reproduces the 3D cantilever-beam topology optimization problem from
-# [Pasteur Labs' Mosaic benchmark suite][mosaic-results], using `dolfinx_adjoint` in
-# place of the original FEniCS/dolfin-adjoint solver. The mesh, material model,
-# boundary conditions and objective follow Mosaic's own reference implementation
-# exactly:
-#
-# - [`fenics-structural/tesseract_api.py`][mosaic-tesseract] — the FEniCS/dolfin-adjoint
-#   physics kernel this demo's weak form and compliance functional mirror.
-# - [`benchmarks/problems/structural_mesh/{physics,optimization,config}.py`][mosaic-benchmark] —
-#   the cantilever boundary-condition builder and the canonical run configuration
-#   (mesh resolution, material parameters, volume-fraction target) reproduced below.
+# [Pasteur Labs' Mosaic benchmark suite][mosaic-results], using
+# {py:mod}`dolfinx_adjoint` in place of the original FEniCS/dolfin-adjoint solver.
+# The mesh, material model, boundary conditions and objective follow Mosaic's own
+# reference implementation.
 #
 # The optimizer differs from Mosaic's own Adam-based recipe: this demo uses
 # `scipy.optimize.minimize(method="trust-constr")`, driven by a
-# `pyadjoint.ReducedFunctionalNumPy`, which — unlike Mosaic's Adam + manual clipping —
+# `pyadjoint.ReducedFunctionalNumPy`, which unlike Mosaic's Adam + manual clipping,
 # enforces the SIMP density bounds natively via `bounds=` while also using exact
-# Hessian-vector products from the adjoint/tangent-linear system (`hessp=`), something
-# Mosaic's first-order Adam recipe does not use at all.
+# Hessian-vector products from the adjoint/tangent-linear system (`hessp=`).
 #
 # The per-iteration density animation uses the pyvista GIF-writing pattern from
 # [`dolfinx-tutorial/chapter2/amr.py`][tutorial-amr].
 #
 # [mosaic-results]: https://docs.pasteurlabs.ai/projects/mosaic/stable/docs/results_structural_mesh.html
-# [mosaic-tesseract]: https://github.com/pasteurlabs/mosaic/blob/main/mosaic/tesseracts/structural-mesh/fenics-structural/tesseract_api.py
-# [mosaic-benchmark]: https://github.com/pasteurlabs/mosaic/tree/main/mosaic/benchmarks/problems/structural_mesh
 # [tutorial-amr]: https://github.com/jorgensd/dolfinx-tutorial/blob/c752d010ddbabf98b3e71e7a562f07ad7a738c26/chapter2/amr.py#L241
 
 # ## Problem definition
 #
-# We minimize the structural compliance $C = \mathbf F^\top \mathbf u$ of a linear
+# We minimize the structural compliance $C = \mathbf{F}^\top \mathbf{u}$ of a linear
 # elastic body $\Omega$ subject to
 #
 # $$
-# -\operatorname{div}(\sigma(\mathbf u)) = 0 \quad \text{in } \Omega, \qquad
-# \mathbf u = 0 \quad \text{on } \Gamma_D, \qquad
-# \sigma(\mathbf u)\cdot n = \mathbf t \quad \text{on } \Gamma_N,
+# \begin{align}
+# -\operatorname{div}(\sigma(\mathbf u)) &= 0 &&\text{in } \Omega,\\
+# \mathbf{u} &= 0 && \text{on } \Gamma_D, \\
+# \sigma(\mathbf u)\cdot n &= \mathbf{t} && \text{on } \Gamma_N,
+# \end{align}
 # $$
 #
 # with a SIMP-interpolated, density-dependent stiffness
@@ -48,15 +41,14 @@
 # and a soft volume-fraction penalty added to the objective,
 #
 # $$
-# \min_{x_\min \le \rho \le 1} \; J(\rho) = C(\rho) + w\,(\bar\rho - v_\mathrm{frac})^2,
-# \qquad \bar\rho = \frac{1}{|\Omega|}\int_\Omega \rho \, \mathrm{d}x.
+# \min_{x_\min \le \rho \le 1} \; J(\rho) &= C(\rho) + w\left(\bar\rho - v_\mathrm{frac}\right)^2,
+# \qquad \bar\rho = \frac{1}{|\Omega|}\int_\Omega \rho~\mathrm{d}x.
 # $$
 #
-# The domain is a $[0,2]\times[0,1]\times[0,1]$ cantilever beam meshed with HEX8
-# elements ($16\times2\times8$ elements), clamped at $x=0$. A prescribed total force
-# $F_\mathrm{total}$ is applied at $x=2$, either as a uniform downward traction over
-# the whole face, or as a concentrated upward traction on a single corner patch — both
-# cases are run below.
+# The domain is a $[0,Lx]\times[0,Ly]\times[0,Lz]$ cantilever beam meshed with hexahedral
+# element, clamped at $x=0$. A prescribed total force $F_\mathrm{total}$ is applied at $x=L$,
+# either as a uniform downward traction over the whole face, or as a concentrated upward traction
+# on a single corner patch.
 
 # ## Implementation
 #
@@ -87,9 +79,7 @@ pyvista.set_jupyter_backend("html")
 # -
 
 # ## Material and problem parameters
-#
-# These match Mosaic's canonical `optimization/topopt` run exactly (see
-# `mosaic/benchmarks/problems/structural_mesh/config.py`).
+# Parameters based on [Pasteur Labs' Mosaic benchmark suite][mosaic-results].
 
 # +
 Lx, Ly, Lz = 2.0, 1.0, 1.0
@@ -107,13 +97,11 @@ penalty_weight = 50.0  # volume-fraction penalty weight
 
 # ## Mesh and boundary conditions
 #
-# `build_mesh_and_bcs` mirrors Mosaic's own `_cantilever_bcs`
-# (`mosaic/benchmarks/problems/structural_mesh/physics.py`): all nodes at $x=0$ are
-# clamped, and the load on the $x=L_x$ face is either a uniform downward traction, or
-# a concentrated upward traction on the single corner patch $y\in[0,\Delta y]$,
-# $z\in[0,\Delta z]$. `dolfinx.mesh.locate_entities_boundary` selects a facet only when
-# *all* of its vertices satisfy the marker, matching the "all vertices in group"
-# semantics Mosaic's own node-mask approach uses.
+# We create a helper function {py:func}`build_mesh_and_bcs`
+# which sets up the mesh and marks the facets to apply the traction on four each use-case.
+# All nodes at $x=0$ are clamped, and the load on the $x=Lx$ face is either a
+# uniform downward traction, or a concentrated upward traction on the single corner patch
+# $y\in[0,\Delta y]$, $z\in[0,\Delta z]$.
 
 
 def build_mesh_and_bcs(nx: int, ny: int, nz: int, corner_load: bool):
@@ -141,9 +129,14 @@ def build_mesh_and_bcs(nx: int, ny: int, nz: int, corner_load: bool):
         traction = (0.0, 0.0, -F_total / (Ly * Lz))  # uniform, downward
 
     right_facets = np.sort(right_facets)
-    facet_tags = dolfinx.mesh.meshtags(msh, fdim, right_facets, np.full(len(right_facets), 1, dtype=np.int32))
-    ds = ufl.Measure("ds", domain=msh, subdomain_data=facet_tags)
-    return msh, left_facets, ds, np.array(traction, dtype=dolfinx.default_scalar_type)
+    facet_map = msh.topology.index_map(fdim)
+    num_facets = facet_map.size_local + facet_map.num_ghosts
+    markers = np.zeros(num_facets, dtype=np.int32)
+    markers[right_facets] = 1
+    markers[left_facets] = 2
+    local_indices = np.flatnonzero(markers).astype(np.int32)
+    facet_tags = dolfinx.mesh.meshtags(msh, fdim, local_indices, markers[local_indices])
+    return msh, facet_tags, np.array(traction, dtype=dolfinx.default_scalar_type)
 
 
 # ## Per-iteration density visualization and compliance history
@@ -152,14 +145,13 @@ def build_mesh_and_bcs(nx: int, ny: int, nz: int, corner_load: bool):
 # pyvista pattern from `dolfinx-tutorial/chapter2/amr.py`. Since a SIMP density field
 # lives in a `("DG", 0)` space, its dof array maps 1-to-1 onto the local cell
 # numbering, so it can be attached directly as `cell_data` on a grid built from the
-# mesh itself (not from the function space). The same callback also records the pure
-# compliance (not the volume-penalized objective) at each iteration, for the
-# compliance-vs-iteration convergence plot Mosaic's own results page shows.
+# mesh itself (not from the function space). We also record the compliance
+# (not the volume-penalized objective) at each iteration.
 #
-# `scipy.optimize.minimize` reports only the penalized objective
+# {py:func}`scipy.optimize.minimize` reports only the penalized objective
 # (`intermediate_result.fun`), so the pure compliance is recovered arithmetically:
 # since every cell of this structured box mesh has equal volume, the volume fraction is
-# exactly `rho.x.array.mean()`, so `compliance = fun - penalty_weight*(vol_frac - v_frac)**2`
+# exactly is the mean of rho, so `compliance = fun - penalty_weight*(vol_frac - v_frac)**2`
 # recovers it with no extra PDE solve.
 
 
@@ -183,7 +175,10 @@ def make_iteration_tracker(
         rho.x.array[:] = intermediate_result.x
         rho.x.scatter_forward()
         write_frame()
-        vol_frac = float(rho.x.array.mean())
+        num_dofs_local = rho.function_space.dofmap.index_map.size_local
+        local_vol_frac = np.sum(rho.x.array[:num_dofs_local])
+        vol = rho.function_space.mesh.comm.allreduce(local_vol_frac, op=MPI.SUM)
+        vol_frac = vol / rho.function_space.dofmap.index_map.size_global
         compliance_history.append(intermediate_result.fun - penalty_weight * (vol_frac - v_frac) ** 2)
 
     write_frame()  # record the initial, uniform density as frame 0
@@ -195,25 +190,20 @@ def make_iteration_tracker(
 # `run_topopt` builds the forward model once (SIMP weak form, linear solve, compliance
 # + volume-penalty objective), verifies the resulting adjoint gradient and Hessian with
 # 0th/1st/2nd-order Taylor tests, times a single tape recompute and a single adjoint
-# solve, then optimizes the density with a bound- and curvature-aware scipy solver.
-#
-# ```{note}
-# A `pyadjoint.ReducedFunctional` *replays* the tape it was built from — it does not
-# re-execute Python code. The forward model below therefore calls `problem.solve()`
-# with annotation on exactly once; every subsequent evaluation goes through
-# `Jhat(...)`/`Jhat.derivative()`/`Jhat.hessian(...)`. `problem` is also kept alive as a
-# local variable for as long as `Jhat` is used, since letting it go out of scope would
-# silently fall back to a much slower solver-rebuild path.
-# ```
+# solve.
 
 
-def run_topopt(corner_load: bool, nx: int = 16, ny: int = 2, nz: int = 8) -> dict:
-    case_name = "corner_load" if corner_load else "full_face_load"
-    print(f"\n=== Running topology optimization: {case_name} ===")
+def run_topopt(
+    corner_load: bool, nx: int = 16, ny: int = 2, nz: int = 8
+) -> tuple[
+    pyadjoint.ReducedFunctional, dolfinx_adjoint.LinearProblem, pyadjoint.AdjFloat, dolfinx_adjoint.Function, dict
+]:
+    print(f"\n=== Running topology optimization: {corner_load=} ===")
 
     pyadjoint.get_working_tape().clear_tape()
 
-    msh, left_facets, ds, traction = build_mesh_and_bcs(nx, ny, nz, corner_load)
+    msh, facet_tags, traction = build_mesh_and_bcs(nx, ny, nz, corner_load)
+    ds = ufl.Measure("ds", domain=msh, subdomain_data=facet_tags)
     fdim = msh.topology.dim - 1
 
     # ### Function spaces and control
@@ -244,7 +234,7 @@ def run_topopt(corner_load: bool, nx: int = 16, ny: int = 2, nz: int = 8) -> dic
     L = ufl.inner(t, v) * ds(1)
 
     # ### Dirichlet BC and forward solve (once)
-    bdofs = dolfinx.fem.locate_dofs_topological(V, fdim, left_facets)
+    bdofs = dolfinx.fem.locate_dofs_topological(V, fdim, facet_tags.find(2))
     bc = dolfinx.fem.dirichletbc(np.zeros(3, dtype=dolfinx.default_scalar_type), bdofs, V)
 
     petsc_options = {
@@ -266,7 +256,7 @@ def run_topopt(corner_load: bool, nx: int = 16, ny: int = 2, nz: int = 8) -> dic
     t_forward_start = time.perf_counter()
     problem.solve()
     forward_time = time.perf_counter() - t_forward_start
-    print(f"[{case_name}] initial forward solve: {forward_time:.4e} s")
+    print(f"[{corner_load=}] initial forward solve: {forward_time:.4e} s")
 
     # ### Objective: compliance + volume-fraction penalty
     compliance = dolfinx_adjoint.assemble_scalar(ufl.action(L, uh))
@@ -277,10 +267,6 @@ def run_topopt(corner_load: bool, nx: int = 16, ny: int = 2, nz: int = 8) -> dic
     Jhat = pyadjoint.ReducedFunctional(J, control)
 
     # ### Gradient and Hessian verification: 0th, 1st and 2nd-order Taylor tests
-    #
-    # Matches the convention used throughout `dxa/tests/` (e.g.
-    # `tests/test_linear_solver.py`, `demos/demo_nonmatching_grids.py`) rather than the
-    # (unused-in-this-repo) upstream `pyadjoint.taylor_to_dict` helper.
     with pyadjoint.stop_annotating():
         h = dolfinx_adjoint.Function(Q)
         rng = np.random.default_rng(seed=42)
@@ -288,15 +274,15 @@ def run_topopt(corner_load: bool, nx: int = 16, ny: int = 2, nz: int = 8) -> dic
         h.x.scatter_forward()
 
         rate0 = pyadjoint.taylor_test(Jhat, rho, h, dJdm=0)
-        print(f"[{case_name}] 0th-order Taylor rate (expect ~1): {rate0:.4f}")
+        print(f"[{corner_load=}] 0th-order Taylor rate (expect ~1): {rate0:.4f}")
         rate1 = pyadjoint.taylor_test(Jhat, rho, h)
-        print(f"[{case_name}] 1st-order Taylor rate (expect ~2): {rate1:.4f}")
+        print(f"[{corner_load=}] 1st-order Taylor rate (expect ~2): {rate1:.4f}")
 
         Jhat(rho)
         dJdm = Jhat.derivative()._ad_dot(h)
         dHddu = Jhat.hessian(h)._ad_dot(h)
         rate2 = pyadjoint.taylor_test(Jhat, rho, h, dJdm=dJdm, Hm=dHddu)
-        print(f"[{case_name}] 2nd-order Taylor rate (expect ~3): {rate2:.4f}")
+        print(f"[{corner_load=}] 2nd-order Taylor rate (expect ~3): {rate2:.4f}")
 
     # ### Cost of one recompute vs. one adjoint solve
     #
@@ -305,21 +291,35 @@ def run_topopt(corner_load: bool, nx: int = 16, ny: int = 2, nz: int = 8) -> dic
     t_recompute_start = time.perf_counter()
     Jhat(rho)
     recompute_time = time.perf_counter() - t_recompute_start
-    print(f"[{case_name}] one tape recompute (Jhat(rho)): {recompute_time:.4e} s")
+    print(f"[{corner_load=}] one tape recompute (Jhat(rho)): {recompute_time:.4e} s")
 
     t_derivative_start = time.perf_counter()
     Jhat.derivative()
     derivative_time = time.perf_counter() - t_derivative_start
-    print(f"[{case_name}] one adjoint solve (Jhat.derivative()): {derivative_time:.4e} s")
+    print(f"[{corner_load=}] one adjoint solve (Jhat.derivative()): {derivative_time:.4e} s")
+    timings = {"recompute_time": recompute_time, "derivative_time": derivative_time, "forward_time": forward_time}
+    return Jhat, problem, compliance, rho, timings
 
-    # ### Bound- and curvature-aware optimization
-    #
-    # `scipy.optimize.minimize(method="trust-constr")` is the scipy method that accepts
-    # *both* `bounds=` and a Hessian-vector product (`hessp=`); `pyadjoint.minimize`'s
-    # convenience wrapper only wires `hessp` automatically for `method="Newton-CG"`
-    # (which has no bounds support), so we drive `scipy.optimize.minimize` directly
-    # from a `pyadjoint.reduced_functional_numpy.ReducedFunctionalNumPy` — the same public class
-    # `pyadjoint.minimize` itself wraps every call in.
+
+# ### Bound- and curvature-aware optimization
+#
+# `scipy.optimize.minimize(method="trust-constr")` is the scipy method that accepts
+# *both* `bounds=` and a Hessian-vector product (`hessp=`); `pyadjoint.minimize`'s
+# convenience wrapper only wires `hessp` automatically for `method="Newton-CG"`
+# (which has no bounds support), so we drive `scipy.optimize.minimize` directly
+# from a `pyadjoint.reduced_functional_numpy.ReducedFunctionalNumPy` — the same public class
+# `pyadjoint.minimize` itself wraps every call in.
+
+
+def optimize(
+    rho: dolfinx_adjoint.Function,
+    Jhat: pyadjoint.ReducedFunctional,
+    problem: dolfinx_adjoint.LinearProblem,
+    compliance: pyadjoint.AdjFloat,
+    corner_load: bool,
+):
+    case_name = "corner_load" if corner_load else "full_face_load"
+    msh = rho.function_space.mesh
     plotter, callback, compliance_history = make_iteration_tracker(
         msh, rho, f"topopt_{case_name}.gif", float(compliance)
     )
@@ -367,9 +367,6 @@ def run_topopt(corner_load: bool, nx: int = 16, ny: int = 2, nz: int = 8) -> dic
         "compliance": float(final_compliance),
         "vol_frac": float(final_vol_frac),
         "n_iterations": int(res.nit),
-        "forward_time": forward_time,
-        "recompute_time": recompute_time,
-        "derivative_time": derivative_time,
         "optim_time": optim_time,
         "compliance_history": compliance_history,
     }
@@ -380,7 +377,12 @@ def run_topopt(corner_load: bool, nx: int = 16, ny: int = 2, nz: int = 8) -> dic
 # Mosaic's canonical `optimization/topopt` run uses `corner_load=True`; we additionally
 # run the uniform full-face load for comparison.
 
-results = [run_topopt(corner_load=True), run_topopt(corner_load=False)]
+results = []
+for corner_load in [True, False]:
+    Jhat, problem, compliance, rho, timings = run_topopt(corner_load)
+    result = optimize(rho, Jhat, problem, compliance, corner_load)
+    result.update(timings)
+    results.append(result)
 
 # ## Summary
 

--- a/demos/topology_optimization.py
+++ b/demos/topology_optimization.py
@@ -348,6 +348,8 @@ def optimize(
     plotter.close()
 
     # Final compliance/volume fraction as plain floats.
+    uh = problem.u
+    L = problem.L
     final_compliance = dolfinx_adjoint.assemble_scalar(ufl.action(L, uh), annotate=False)
     final_vol_frac = dolfinx_adjoint.assemble_scalar(rho * ufl.dx, annotate=False) / (Lx * Ly * Lz)
 

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -71,3 +71,14 @@
   isbn      = {978-3-030-61157-6},
   doi       = {10.1007/978-3-030-61157-6_5}
 }
+
+
+@misc{rehmann2026mosaic,
+      title={Mosaic: A Benchmark Suite for Differentiable Physics Solvers}, 
+      author={Andrin Rehmann and Heiko Zimmermann and Dion Häfner},
+      year={2026},
+      eprint={2606.27895},
+      archivePrefix={arXiv},
+      primaryClass={physics.comp-ph},
+      url={https://arxiv.org/abs/2606.27895}, 
+}

--- a/src/dolfinx_adjoint/blocks/function_assigner.py
+++ b/src/dolfinx_adjoint/blocks/function_assigner.py
@@ -1,4 +1,3 @@
-
 import dolfinx
 import numpy as np
 import numpy.typing as npt

--- a/src/dolfinx_adjoint/solvers.py
+++ b/src/dolfinx_adjoint/solvers.py
@@ -341,7 +341,8 @@ class _ProblemBase(abc.ABC):
             # callers wanting a single summed form (Hessian templating,
             # scalar-only) apply ufl_utils.sum_form() themselves.
             self._dFdu_adj_template = compute_adjoint(
-                self._get_or_build_dFdu_template()  # type: ignore[arg-type]
+                self._get_or_build_dFdu_template(),  # type: ignore[arg-type]
+                blocked=isinstance(self._u, list),
             )
         return self._dFdu_adj_template
 

--- a/src/dolfinx_adjoint/ufl_utils.py
+++ b/src/dolfinx_adjoint/ufl_utils.py
@@ -181,18 +181,30 @@ def sum_form(form: NestedSequence[ufl.Form | None]) -> ufl.Form | None:
         raise TypeError(f"Cannot sum form of type {type(form)}")
 
 
-def compute_adjoint(form: ufl.Form) -> typing.Sequence[typing.Sequence[ufl.Form]] | ufl.Form:
+def compute_adjoint(form: ufl.Form, blocked: bool = True) -> typing.Sequence[typing.Sequence[ufl.Form]] | ufl.Form:
     """Compute the adjoint of a (possibly blocked) bilinear form.
 
     Args:
         form: A bilinear form :math:`a(u, v)`. Blocked forms should be summed with
-        {py:func}`sum_form` before passing to this function.
+            {py:func}`sum_form` before passing to this function.
+        blocked: Whether ``form``'s arguments come from a genuine blocked/mixed
+            problem (multiple ``Argument``s with distinct ``part()`` tags). When
+            ``False``, ``ufl.extract_blocks`` is skipped entirely: a plain scalar
+            or vector-*shaped* (non-mixed) argument still reports multiple
+            "parts" to UFL, so ``extract_blocks`` would otherwise decompose the
+            single bilinear form into spurious blocks that each still reference
+            the original, full-space ``Argument`` -- producing a system sized
+            for several redundant copies of the space once assembled.
 
     Returns:
-        The transposed form :math:`a(v, u)`, decomposed back into blocks (via
-        ``ufl.extract_blocks``) -- a no-op decomposition for a scalar form.
+        The transposed form :math:`a(v, u)`: a single ``ufl.Form`` when
+        ``blocked=False``, else decomposed back into blocks via
+        ``ufl.extract_blocks`` (a no-op decomposition for a scalar form).
     """
-    return ufl.extract_blocks(compute_form_adjoint(form))
+    adjoint_form = compute_form_adjoint(form)
+    if not blocked:
+        return adjoint_form
+    return ufl.extract_blocks(adjoint_form)
 
 
 def recursive_replace(form: ufl.Form | typing.Sequence | None, placeholders: dict) -> ufl.Form | typing.Sequence | None:

--- a/tests/test_blocked_problem.py
+++ b/tests/test_blocked_problem.py
@@ -269,11 +269,25 @@ def test_nonlinear_solver(use_mixed_space: bool, mesh_2D):
     forward_options = {
         "snes_monitor": None,
         "snes_type": "newtonls",
-        "snes_linesearch_type": "none",
+        # Default ("bt") backtracking line search: globalizes genuinely-far Newton
+        # steps (e.g. the largest Taylor-test perturbations). Disabling it
+        # ("snes_linesearch_type": "none") let an undamped step stall -- SNES then
+        # reported SNES_CONVERGED_SNORM_RELATIVE (step size below snes_stol) even
+        # though the residual was still ~1e-1, and snes_error_if_not_converged only
+        # raises on a *diverged* reason, so that false convergence passed silently.
         "snes_error_if_not_converged": True,
-        "snes_atol": 1e-9,
-        "snes_rtol": 1e-9,
-        "snes_stol": 1e-12,
+        # atol/rtol=1e-9 (tighter than this) plus line search re-enabled instead
+        # traded that silent failure for a *real* DIVERGED_LINE_SEARCH: warm-started
+        # from a neighbouring perturbation's solution, this problem's Newton
+        # iteration plateaus around residual ~9e-7 for many iterations before line
+        # search can no longer find a decrease -- 1e-9 is simply unreachable there.
+        # 1e-8 is comfortably above that plateau, so every recompute in the Taylor
+        # sweep below converges via the residual (not the step-size) criterion, in a
+        # single warm-started Newton iteration, well clear of both failure modes.
+        "snes_atol": 1e-8,
+        "snes_rtol": 1e-8,
+        # No explicit snes_stol: PETSc's default is loose enough, now that atol/rtol
+        # are the binding criteria, not to trigger a premature step-based exit.
         "ksp_type": "preonly",
         "ksp_error_if_not_converged": True,
         "pc_type": "lu",

--- a/tests/test_blocked_problem.py
+++ b/tests/test_blocked_problem.py
@@ -280,14 +280,7 @@ def test_nonlinear_solver(use_mixed_space: bool, mesh_2D):
     bc = dolfinx.fem.dirichletbc(bc_val, boundary_dofs, V)
 
     forward_options = {
-        "snes_monitor": None,
         "snes_type": "newtonls",
-        # Default ("bt") backtracking line search: globalizes genuinely-far Newton
-        # steps (e.g. the largest Taylor-test perturbations). Disabling it
-        # ("snes_linesearch_type": "none") let an undamped step stall -- SNES then
-        # reported SNES_CONVERGED_SNORM_RELATIVE (step size below snes_stol) even
-        # though the residual was still ~1e-1, and snes_error_if_not_converged only
-        # raises on a *diverged* reason, so that false convergence passed silently.
         "snes_error_if_not_converged": True,
         "snes_atol": 1e-9,
         "snes_rtol": 1e-9,

--- a/tests/test_blocked_problem.py
+++ b/tests/test_blocked_problem.py
@@ -129,6 +129,90 @@ def test_solver(use_mixed_space: bool, mesh_2D):
     assert np.isclose(min_rate, 3.0, rtol=0.1, atol=0.1), f"Expected convergence rate close to 3.0, got {min_rate}"
 
 
+def test_vector_valued_solver(mesh_2D):
+    """Regression test for a spurious block-extraction bug on plain vector-valued spaces.
+
+    Unlike ``test_solver``'s two parametrizations -- a genuine ``ufl.MixedFunctionSpace``
+    (``use_mixed_space=True``) and an explicit list-of-lists two-field system
+    (``use_mixed_space=False``, but still two separate function spaces and a
+    ``u=[uh, ph]`` list) -- this problem has a *single* state ``Function`` (not a list)
+    on one plain vector-*shaped* space (``("Lagrange", 1, (gdim,))``), exactly the shape
+    every vector-PDE problem (e.g. elasticity) uses.
+
+    Before the fix, ``compute_adjoint`` called ``ufl.extract_blocks`` unconditionally,
+    which still decomposes a shaped (non-mixed) argument into spurious blocks even
+    though there is no genuine block structure here. That first raised
+    ``AttributeError: 'FunctionSpace' object has no attribute '_cpp_object'`` (a bare
+    ``ufl.FunctionSpace`` lost its dolfinx wrapper during the spurious extraction), and
+    after passing ``replace_argument=False``, a PETSc size mismatch instead (each
+    spurious block still referenced the original, full-space ``Argument``, so the
+    assembled adjoint operator came out sized for several redundant copies of the
+    space). The fix threads ``blocked=isinstance(self._u, list)`` through
+    ``compute_adjoint`` so block-extraction only runs for a genuinely blocked/mixed
+    problem.
+    """
+    pyadjoint.get_working_tape().clear_tape()
+    mesh = mesh_2D
+    gdim = mesh.geometry.dim
+    V = dolfinx.fem.functionspace(mesh, ("Lagrange", 1, (gdim,)))
+    Z = dolfinx.fem.functionspace(mesh, ("DG", 0))
+
+    # The control multiplies the bilinear form (not just the right-hand side), as in
+    # a SIMP-style density-dependent stiffness -- the structure that first surfaced
+    # this bug in a linear-elasticity topology optimization demo.
+    kappa = Function(Z, name="control")
+    kappa.interpolate(lambda x: 1.0 + 0.5 * np.sin(np.pi * x[0]))
+
+    u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
+    a = kappa * ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx
+    x = ufl.SpatialCoordinate(mesh)
+    f = ufl.as_vector((ufl.sin(ufl.pi * x[1]), ufl.cos(ufl.pi * x[0])))
+    L = ufl.inner(f, v) * ufl.dx
+
+    mesh.topology.create_connectivity(mesh.topology.dim - 1, mesh.topology.dim)
+    boundary_facets = dolfinx.mesh.exterior_facet_indices(mesh.topology)
+    boundary_dofs = dolfinx.fem.locate_dofs_topological(V, mesh.topology.dim - 1, boundary_facets)
+    bc_val = dolfinx.fem.Constant(mesh, np.zeros((gdim,), dtype=dolfinx.default_scalar_type))
+    bc = dolfinx.fem.dirichletbc(bc_val, boundary_dofs, V)
+
+    uh = Function(V, name="state")
+    problem = LinearProblem(
+        a,
+        L,
+        u=uh,
+        bcs=[bc],
+        petsc_options=direct_solve,
+        adjoint_petsc_options=direct_solve,
+        tlm_petsc_options=direct_solve,
+    )
+    problem.solve()
+
+    # Quartic in the state, for the same round-off-avoidance reason as test_solver's
+    # objective.
+    J = assemble_scalar(ufl.inner(uh, uh) ** 2 * ufl.dx)
+
+    control = pyadjoint.Control(kappa)
+    Jh = pyadjoint.ReducedFunctional(J, control)
+    d = Function(Z)
+    d.interpolate(lambda x: 1.0 + 0.3 * np.cos(np.pi * x[1]))
+    e = Function(Z)
+    e.interpolate(lambda x: 0.2 * np.sin(3 * x[0]))
+
+    min_rate = pyadjoint.taylor_test(Jh, d, e, dJdm=0)
+    assert np.isclose(min_rate, 1.0, rtol=1e-1, atol=1e-1), f"Expected convergence rate close to 1.0, got {min_rate}"
+
+    Jh.derivative()
+    min_rate = pyadjoint.taylor_test(Jh, d, e)
+    assert np.isclose(min_rate, 2.0, rtol=1e-2, atol=1e-2), f"Expected convergence rate close to 2.0, got {min_rate}"
+
+    Jh(d)
+    dJdm = Jh.derivative()._ad_dot(e)
+    hessian = Jh.hessian(e)
+    dHddu = hessian._ad_dot(e)
+    min_rate = pyadjoint.taylor_test(Jh, d, e, dJdm=dJdm, Hm=dHddu)
+    assert np.isclose(min_rate, 3.0, rtol=0.1, atol=0.1), f"Expected convergence rate close to 3.0, got {min_rate}"
+
+
 @pytest.mark.parametrize("use_mixed_space", [True, False])
 def test_nonlinear_solver(use_mixed_space: bool, mesh_2D):
     """As ``test_solver``, but for a blocked ``NonlinearProblem``: a Navier-Stokes-like
@@ -183,12 +267,15 @@ def test_nonlinear_solver(use_mixed_space: bool, mesh_2D):
     bc = dolfinx.fem.dirichletbc(bc_val, boundary_dofs, V)
 
     forward_options = {
+        "snes_monitor": None,
         "snes_type": "newtonls",
+        "snes_linesearch_type": "none",
         "snes_error_if_not_converged": True,
         "snes_atol": 1e-9,
         "snes_rtol": 1e-9,
         "snes_stol": 1e-12,
         "ksp_type": "preonly",
+        "ksp_error_if_not_converged": True,
         "pc_type": "lu",
         "pc_factor_mat_solver_type": "mumps",
     }

--- a/tests/test_blocked_problem.py
+++ b/tests/test_blocked_problem.py
@@ -147,24 +147,9 @@ def test_solver(use_mixed_space: bool, mesh_2D, assert_hessian_matches_finite_di
 def test_vector_valued_solver(mesh_2D):
     """Regression test for a spurious block-extraction bug on plain vector-valued spaces.
 
-    Unlike ``test_solver``'s two parametrizations -- a genuine ``ufl.MixedFunctionSpace``
-    (``use_mixed_space=True``) and an explicit list-of-lists two-field system
-    (``use_mixed_space=False``, but still two separate function spaces and a
-    ``u=[uh, ph]`` list) -- this problem has a *single* state ``Function`` (not a list)
-    on one plain vector-*shaped* space (``("Lagrange", 1, (gdim,))``), exactly the shape
-    every vector-PDE problem (e.g. elasticity) uses.
-
-    Before the fix, ``compute_adjoint`` called ``ufl.extract_blocks`` unconditionally,
-    which still decomposes a shaped (non-mixed) argument into spurious blocks even
-    though there is no genuine block structure here. That first raised
-    ``AttributeError: 'FunctionSpace' object has no attribute '_cpp_object'`` (a bare
-    ``ufl.FunctionSpace`` lost its dolfinx wrapper during the spurious extraction), and
-    after passing ``replace_argument=False``, a PETSc size mismatch instead (each
-    spurious block still referenced the original, full-space ``Argument``, so the
-    assembled adjoint operator came out sized for several redundant copies of the
-    space). The fix threads ``blocked=isinstance(self._u, list)`` through
-    ``compute_adjoint`` so block-extraction only runs for a genuinely blocked/mixed
-    problem.
+    Previous tests didn't check {py:func}`ufl.extract_blocks` on
+    a single vector-valued space, only on a mixed space.
+    This test checks that we don't call extract_blocks on single-space forms.
     """
     pyadjoint.get_working_tape().clear_tape()
     mesh = mesh_2D
@@ -172,9 +157,8 @@ def test_vector_valued_solver(mesh_2D):
     V = dolfinx.fem.functionspace(mesh, ("Lagrange", 1, (gdim,)))
     Z = dolfinx.fem.functionspace(mesh, ("DG", 0))
 
-    # The control multiplies the bilinear form (not just the right-hand side), as in
-    # a SIMP-style density-dependent stiffness -- the structure that first surfaced
-    # this bug in a linear-elasticity topology optimization demo.
+    # The control multiplies the bilinear form (not just the right-hand side),
+    # as in a SIMP-style density-dependent stiffness.
     kappa = Function(Z, name="control")
     kappa.interpolate(lambda x: 1.0 + 0.5 * np.sin(np.pi * x[0]))
 
@@ -202,8 +186,7 @@ def test_vector_valued_solver(mesh_2D):
     )
     problem.solve()
 
-    # Quartic in the state, for the same round-off-avoidance reason as test_solver's
-    # objective.
+    # Quartic in the state to get good Taylor test remainders
     J = assemble_scalar(ufl.inner(uh, uh) ** 2 * ufl.dx)
 
     control = pyadjoint.Control(kappa)


### PR DESCRIPTION
Implementation of the structural problem from Pasteur Labs (mosaic) using DOLFINx adjoint.
Heads up @dionhaefner :)

Instead of using ADAM I've opted for using an optimization solver that can use reduced hessian vector products as well.

## Bug-fixes along the way
- Compute_adjoint split blocked elements when calling extract_blocks. This was not intentional and therefore we now ensure that blocks are not extracted for the un-blocked case. Test added to verify that this was an issue on main.
~~- Nonlinear test locally exposed an issue with snes converging early if tolerance is too low.~~: This has been fixed properly on main with #82 

## Summary of outputs:
[corner_load] one tape recompute (Jhat(rho)): 4.7843e-02 s
[corner_load] one adjoint solve (Jhat.derivative()): 6.0980e-02 s

[full_face_load] one tape recompute (Jhat(rho)): 5.1036e-02 s
[full_face_load] one adjoint solve (Jhat.derivative()): 6.2825e-02 s

<img width="897" height="678" alt="topopt_compliance_convergence" src="https://github.com/user-attachments/assets/0ab6e8e8-fabe-4c15-8ffd-1cd7a00e01d5" />
<img width="1024" height="768" alt="topopt_full_face_load_final" src="https://github.com/user-attachments/assets/e6eabdb7-aa00-4838-8f55-0899c158fa44" />
<img width="1024" height="768" alt="topopt_full_face_load" src="https://github.com/user-attachments/assets/9a1162d5-62cd-4b94-be77-a73f9c8041c1" />
<img width="1024" height="768" alt="topopt_corner_load_final" src="https://github.com/user-attachments/assets/fe9a80c7-7fc0-4647-adf0-e4ac8895a37f" />
<img width="1024" height="768" alt="topopt_corner_load" src="https://github.com/user-attachments/assets/f072762c-4e44-4570-8fb2-689e18130e6b" />
